### PR TITLE
Add elide_directory keyword for install_subdir() function

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -772,7 +772,7 @@ installed with a `.gz` suffix.
 ### install_subdir()
 
 ``` meson
-    void install_subdir(subdir_name, install_dir : ..., exclude_files : ..., exclude_directories : ...)
+    void install_subdir(subdir_name, install_dir : ..., exclude_files : ..., exclude_directories : ..., elide_directory : ...)
 ```
 
 Installs the entire given subdirectory and its contents from the
@@ -786,6 +786,32 @@ The following keyword arguments are supported:
 - `exclude_directories`: a list of directory names that should not be installed.
   Names are interpreted as paths relative to the `subdir_name` location.
 - `install_dir`: the location to place the installed subdirectory.
+- `elide_directory`: install directory contents. `elide_directory=false` by default.
+  Since 0.45.0
+
+For a given directory `foo`:
+```
+foo/
+  bar/
+    file1
+  file2
+```
+`install_subdir('foo', install_dir : 'share', elide_directory : false)` creates
+```
+share/
+  foo/
+    bar/
+      file1
+    file2
+```
+
+`install_subdir('foo', install_dir : 'share', elide_directory : true)` creates
+```
+share/
+  bar/
+    file1
+  file2
+```
 
 ### is_variable()
 

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -814,7 +814,7 @@ share/
   file2
 ```
 
-`install_subdir('foo/bar', install_dir : 'share', stripe_directory : false)` creates
+`install_subdir('foo/bar', install_dir : 'share', strip_directory : false)` creates
 ```
 share/
   bar/

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -787,6 +787,7 @@ The following keyword arguments are supported:
   Names are interpreted as paths relative to the `subdir_name` location.
 - `install_dir`: the location to place the installed subdirectory.
 - `strip_directory`: install directory contents. `strip_directory=false` by default.
+  If `strip_directory=false` only last component of source path is used.
   Since 0.45.0
 
 For a given directory `foo`:
@@ -811,6 +812,13 @@ share/
   bar/
     file1
   file2
+```
+
+`install_subdir('foo/bar', install_dir : 'share', stripe_directory : false)` creates
+```
+share/
+  bar/
+    file1
 ```
 
 ### is_variable()

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -791,14 +791,14 @@ The following keyword arguments are supported:
   Since 0.45.0
 
 For a given directory `foo`:
-```
+```text
 foo/
   bar/
     file1
   file2
 ```
 `install_subdir('foo', install_dir : 'share', strip_directory : false)` creates
-```
+```text
 share/
   foo/
     bar/
@@ -807,7 +807,7 @@ share/
 ```
 
 `install_subdir('foo', install_dir : 'share', strip_directory : true)` creates
-```
+```text
 share/
   bar/
     file1
@@ -815,14 +815,14 @@ share/
 ```
 
 `install_subdir('foo/bar', install_dir : 'share', strip_directory : false)` creates
-```
+```text
 share/
   bar/
     file1
 ```
 
 `install_subdir('foo/bar', install_dir : 'share', strip_directory : true)` creates
-```
+```text
 share/
   file1
 ```

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -821,6 +821,12 @@ share/
     file1
 ```
 
+`install_subdir('foo/bar', install_dir : 'share', strip_directory : true)` creates
+```
+share/
+  file1
+```
+
 ### is_variable()
 
 ``` meson

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -945,13 +945,16 @@ respectively.
 ### run_target
 
 ``` meson
-    buildtarget run_target(target_name, ...)
+runtarget run_target(target_name, ...)
 ```
 
 This function creates a new top-level target that runs a specified
 command with the specified arguments. Like all top-level targets, this
 integrates with the selected backend. For instance, with Ninja you can
-run it as `ninja target_name`.
+run it as `ninja target_name`. Note that a run target produces no
+output as far as Meson is concerned. It is only meant for tasks such
+as running a code formatter or flashing an external device's firmware
+with a built file.
 
 The script is run from an *unspecified* directory, and Meson will set
 three environment variables `MESON_SOURCE_ROOT`, `MESON_BUILD_ROOT`

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -772,7 +772,7 @@ installed with a `.gz` suffix.
 ### install_subdir()
 
 ``` meson
-    void install_subdir(subdir_name, install_dir : ..., exclude_files : ..., exclude_directories : ..., elide_directory : ...)
+    void install_subdir(subdir_name, install_dir : ..., exclude_files : ..., exclude_directories : ..., strip_directory : ...)
 ```
 
 Installs the entire given subdirectory and its contents from the
@@ -786,7 +786,7 @@ The following keyword arguments are supported:
 - `exclude_directories`: a list of directory names that should not be installed.
   Names are interpreted as paths relative to the `subdir_name` location.
 - `install_dir`: the location to place the installed subdirectory.
-- `elide_directory`: install directory contents. `elide_directory=false` by default.
+- `strip_directory`: install directory contents. `strip_directory=false` by default.
   Since 0.45.0
 
 For a given directory `foo`:
@@ -796,7 +796,7 @@ foo/
     file1
   file2
 ```
-`install_subdir('foo', install_dir : 'share', elide_directory : false)` creates
+`install_subdir('foo', install_dir : 'share', strip_directory : false)` creates
 ```
 share/
   foo/
@@ -805,7 +805,7 @@ share/
     file2
 ```
 
-`install_subdir('foo', install_dir : 'share', elide_directory : true)` creates
+`install_subdir('foo', install_dir : 'share', strip_directory : true)` creates
 ```
 share/
   bar/

--- a/docs/markdown/snippets/install_subdir-elide_directory.md
+++ b/docs/markdown/snippets/install_subdir-elide_directory.md
@@ -1,0 +1,4 @@
+## install_subdir() supports elide_directory
+
+If elide_directory=true install_subdir() installs directory contents
+instead of directory itself, eliding name of the source directory.

--- a/docs/markdown/snippets/install_subdir-elide_directory.md
+++ b/docs/markdown/snippets/install_subdir-elide_directory.md
@@ -1,4 +1,0 @@
-## install_subdir() supports elide_directory
-
-If elide_directory=true install_subdir() installs directory contents
-instead of directory itself, eliding name of the source directory.

--- a/docs/markdown/snippets/install_subdir-strip_directory.md
+++ b/docs/markdown/snippets/install_subdir-strip_directory.md
@@ -1,0 +1,4 @@
+## install_subdir() supports strip_directory
+
+If strip_directory=true install_subdir() installs directory contents
+instead of directory itself, stripping basename of the source directory.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -851,8 +851,9 @@ int dummy;
                                    sd.source_subdir,
                                    sd.installable_subdir).rstrip('/')
             dst_dir = os.path.join(self.environment.get_prefix(),
-                                   sd.install_dir,
-                                   os.path.basename(src_dir))
+                                   sd.install_dir)
+            if not sd.elide_directory:
+                dst_dir = os.path.join(dst_dir, os.path.basename(src_dir))
             d.install_subdirs.append([src_dir, dst_dir, sd.install_mode,
                                       sd.exclude])
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -852,7 +852,7 @@ int dummy;
                                    sd.installable_subdir).rstrip('/')
             dst_dir = os.path.join(self.environment.get_prefix(),
                                    sd.install_dir)
-            if not sd.elide_directory:
+            if not sd.strip_directory:
                 dst_dir = os.path.join(dst_dir, os.path.basename(src_dir))
             d.install_subdirs.append([src_dir, dst_dir, sd.install_mode,
                                       sd.exclude])

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -507,14 +507,14 @@ class DataHolder(InterpreterObject, ObjectHolder):
         return self.held_object.install_dir
 
 class InstallDir(InterpreterObject):
-    def __init__(self, src_subdir, inst_subdir, install_dir, install_mode, exclude, elide_directory):
+    def __init__(self, src_subdir, inst_subdir, install_dir, install_mode, exclude, strip_directory):
         InterpreterObject.__init__(self)
         self.source_subdir = src_subdir
         self.installable_subdir = inst_subdir
         self.install_dir = install_dir
         self.install_mode = install_mode
         self.exclude = exclude
-        self.elide_directory = elide_directory
+        self.strip_directory = strip_directory
 
 class Man(InterpreterObject):
 
@@ -1391,7 +1391,7 @@ permitted_kwargs = {'add_global_arguments': {'language'},
                     'install_data': {'install_dir', 'install_mode', 'sources'},
                     'install_headers': {'install_dir', 'subdir'},
                     'install_man': {'install_dir'},
-                    'install_subdir': {'elide_directory', 'exclude_files', 'exclude_directories', 'install_dir', 'install_mode'},
+                    'install_subdir': {'exclude_files', 'exclude_directories', 'install_dir', 'install_mode', 'strip_directory'},
                     'jar': jar_kwargs,
                     'project': {'version', 'meson_version', 'default_options', 'license', 'subproject_dir'},
                     'run_target': {'command', 'depends'},
@@ -2675,12 +2675,12 @@ root and issuing %s.
         install_dir = kwargs['install_dir']
         if not isinstance(install_dir, str):
             raise InvalidArguments('Keyword argument install_dir not a string.')
-        if 'elide_directory' in kwargs:
-            if not isinstance(kwargs['elide_directory'], bool):
-                raise InterpreterException('"elide_directory" keyword must be a boolean.')
-            elide_directory = kwargs['elide_directory']
+        if 'strip_directory' in kwargs:
+            if not isinstance(kwargs['strip_directory'], bool):
+                raise InterpreterException('"strip_directory" keyword must be a boolean.')
+            strip_directory = kwargs['strip_directory']
         else:
-            elide_directory = False
+            strip_directory = False
         if 'exclude_files' in kwargs:
             exclude = extract_as_list(kwargs, 'exclude_files')
             for f in exclude:
@@ -2703,7 +2703,7 @@ root and issuing %s.
             exclude_directories = set()
         exclude = (exclude_files, exclude_directories)
         install_mode = self._get_kwarg_install_mode(kwargs)
-        idir = InstallDir(self.subdir, subdir, install_dir, install_mode, exclude, elide_directory)
+        idir = InstallDir(self.subdir, subdir, install_dir, install_mode, exclude, strip_directory)
         self.build.install_dirs.append(idir)
         return idir
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -507,13 +507,14 @@ class DataHolder(InterpreterObject, ObjectHolder):
         return self.held_object.install_dir
 
 class InstallDir(InterpreterObject):
-    def __init__(self, src_subdir, inst_subdir, install_dir, install_mode, exclude):
+    def __init__(self, src_subdir, inst_subdir, install_dir, install_mode, exclude, elide_directory):
         InterpreterObject.__init__(self)
         self.source_subdir = src_subdir
         self.installable_subdir = inst_subdir
         self.install_dir = install_dir
         self.install_mode = install_mode
         self.exclude = exclude
+        self.elide_directory = elide_directory
 
 class Man(InterpreterObject):
 
@@ -1390,7 +1391,7 @@ permitted_kwargs = {'add_global_arguments': {'language'},
                     'install_data': {'install_dir', 'install_mode', 'sources'},
                     'install_headers': {'install_dir', 'subdir'},
                     'install_man': {'install_dir'},
-                    'install_subdir': {'exclude_files', 'exclude_directories', 'install_dir', 'install_mode'},
+                    'install_subdir': {'elide_directory', 'exclude_files', 'exclude_directories', 'install_dir', 'install_mode'},
                     'jar': jar_kwargs,
                     'project': {'version', 'meson_version', 'default_options', 'license', 'subproject_dir'},
                     'run_target': {'command', 'depends'},
@@ -2674,6 +2675,12 @@ root and issuing %s.
         install_dir = kwargs['install_dir']
         if not isinstance(install_dir, str):
             raise InvalidArguments('Keyword argument install_dir not a string.')
+        if 'elide_directory' in kwargs:
+            if not isinstance(kwargs['elide_directory'], bool):
+                raise InterpreterException('"elide_directory" keyword must be a boolean.')
+            elide_directory = kwargs['elide_directory']
+        else:
+            elide_directory = False
         if 'exclude_files' in kwargs:
             exclude = extract_as_list(kwargs, 'exclude_files')
             for f in exclude:
@@ -2696,7 +2703,7 @@ root and issuing %s.
             exclude_directories = set()
         exclude = (exclude_files, exclude_directories)
         install_mode = self._get_kwarg_install_mode(kwargs)
-        idir = InstallDir(self.subdir, subdir, install_dir, install_mode, exclude)
+        idir = InstallDir(self.subdir, subdir, install_dir, install_mode, exclude, elide_directory)
         self.build.install_dirs.append(idir)
         return idir
 

--- a/test cases/common/66 install subdir/installed_files.txt
+++ b/test cases/common/66 install subdir/installed_files.txt
@@ -1,3 +1,9 @@
+usr/share/dircheck/fifth.dat
+usr/share/dircheck/seventh.dat
+usr/share/dircheck/nineth.dat
+usr/share/eighth.dat
+usr/share/fourth.dat
+usr/share/sixth.dat
 usr/share/sub1/data1.dat
 usr/share/sub1/second.dat
 usr/share/sub1/third.dat

--- a/test cases/common/66 install subdir/meson.build
+++ b/test cases/common/66 install subdir/meson.build
@@ -11,3 +11,7 @@ subdir('subdir')
 # and read-list perms for owner and group
 install_subdir('sub1', install_dir : 'share', install_mode : ['rwxr-x--t', 'root'])
 install_subdir('sub/sub1', install_dir : 'share')
+
+# elide_directory
+install_subdir('sub_elided', install_dir : 'share', elide_directory : true)
+install_subdir('nested_elided/sub', install_dir : 'share', elide_directory : true)

--- a/test cases/common/66 install subdir/meson.build
+++ b/test cases/common/66 install subdir/meson.build
@@ -12,6 +12,6 @@ subdir('subdir')
 install_subdir('sub1', install_dir : 'share', install_mode : ['rwxr-x--t', 'root'])
 install_subdir('sub/sub1', install_dir : 'share')
 
-# elide_directory
-install_subdir('sub_elided', install_dir : 'share', elide_directory : true)
-install_subdir('nested_elided/sub', install_dir : 'share', elide_directory : true)
+# strip_directory
+install_subdir('sub_elided', install_dir : 'share', strip_directory : true)
+install_subdir('nested_elided/sub', install_dir : 'share', strip_directory : true)

--- a/test cases/common/66 install subdir/nested_elided/sub/dircheck/nineth.dat
+++ b/test cases/common/66 install subdir/nested_elided/sub/dircheck/nineth.dat
@@ -1,0 +1,1 @@
+Nested file under nested elided directory.

--- a/test cases/common/66 install subdir/nested_elided/sub/eighth.dat
+++ b/test cases/common/66 install subdir/nested_elided/sub/eighth.dat
@@ -1,0 +1,1 @@
+File in nested elided directory.

--- a/test cases/common/66 install subdir/sub_elided/dircheck/fifth.dat
+++ b/test cases/common/66 install subdir/sub_elided/dircheck/fifth.dat
@@ -1,0 +1,1 @@
+Data file in a subdir of elided directory.

--- a/test cases/common/66 install subdir/sub_elided/fourth.dat
+++ b/test cases/common/66 install subdir/sub_elided/fourth.dat
@@ -1,0 +1,1 @@
+Test that this file is installed directly into install_dir.

--- a/test cases/common/66 install subdir/subdir/meson.build
+++ b/test cases/common/66 install subdir/subdir/meson.build
@@ -2,4 +2,4 @@ install_subdir('sub1', install_dir : 'share',
   # This mode will be overridden by the mode set in the outer install_subdir
   install_mode : 'rwxr-x---')
 
-install_subdir('sub_elided', install_dir : 'share', elide_directory : true)
+install_subdir('sub_elided', install_dir : 'share', strip_directory : true)

--- a/test cases/common/66 install subdir/subdir/meson.build
+++ b/test cases/common/66 install subdir/subdir/meson.build
@@ -1,3 +1,5 @@
 install_subdir('sub1', install_dir : 'share',
   # This mode will be overridden by the mode set in the outer install_subdir
   install_mode : 'rwxr-x---')
+
+install_subdir('sub_elided', install_dir : 'share', elide_directory : true)

--- a/test cases/common/66 install subdir/subdir/sub_elided/dircheck/seventh.dat
+++ b/test cases/common/66 install subdir/subdir/sub_elided/dircheck/seventh.dat
@@ -1,0 +1,1 @@
+Nested file in a subdir.

--- a/test cases/common/66 install subdir/subdir/sub_elided/sixth.dat
+++ b/test cases/common/66 install subdir/subdir/sub_elided/sixth.dat
@@ -1,0 +1,1 @@
+Elide test file in a subdir.

--- a/test cases/frameworks/1 boost/linkexe.cc
+++ b/test cases/frameworks/1 boost/linkexe.cc
@@ -1,3 +1,5 @@
+#define _XOPEN_SOURCE 500
+
 #include<boost/thread.hpp>
 
 boost::recursive_mutex m;


### PR DESCRIPTION
If elide_directory=true install_subdir() installs directory contents
instead of directory itself, eliding name of the source directory.

Closes #2869.